### PR TITLE
Got strings and floats working from Go to Python

### DIFF
--- a/section1/commands.sh
+++ b/section1/commands.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 go build -o hello_world.so  -buildmode=c-shared hello_world.go

--- a/section2/bool/commands.sh
+++ b/section2/bool/commands.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 go build -o bool_input.so  -buildmode=c-shared bool_input.go
 go build -o bool_output.so  -buildmode=c-shared bool_output.go

--- a/section2/dict/commands.sh
+++ b/section2/dict/commands.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 go build -o dict_input.so  -buildmode=c-shared dict_input.go

--- a/section2/float/commands.sh
+++ b/section2/float/commands.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 go build -o float_input.so  -buildmode=c-shared float_input.go
 go build -o float_output.so  -buildmode=c-shared float_output.go
 go build -o float_output_cgo.so  -buildmode=c-shared float_output_cgo.go

--- a/section2/float/float_output.py
+++ b/section2/float/float_output.py
@@ -1,9 +1,11 @@
 import ctypes
 import os
 
+
 def main():
     path = os.path.join(os.path.abspath("."), "float_output.so")
-    lib = ctypes.CDLL(path)
+    lib = ctypes.cdll.LoadLibrary(path)
+    lib.float_output.restype = ctypes.c_double
     print("Answer is: ")
     print("-------------------")
     answer = lib.float_output()
@@ -12,4 +14,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/section2/ints/commands.sh
+++ b/section2/ints/commands.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 go build -o int_input.so  -buildmode=c-shared int_input.go
 go build -o int_output.so  -buildmode=c-shared int_output.go

--- a/section2/list/commands.sh
+++ b/section2/list/commands.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 go build -o list_input.so  -buildmode=c-shared list_input.go

--- a/section2/strings/commands.sh
+++ b/section2/strings/commands.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 go build -o string_input.so  -buildmode=c-shared string_input.go
 go build -o string_input_cgo.so  -buildmode=c-shared string_input_cgo.go
 go build -o string_output.so  -buildmode=c-shared string_output.go

--- a/section2/strings/string_output_cgo.go
+++ b/section2/strings/string_output_cgo.go
@@ -1,10 +1,14 @@
 package main
 
+// #include <stdlib.h>
 import "C"
+import "unsafe"
 
 //export string_output
 func string_output() *C.char {
-    return C.CString("Hello")
+    var cstr = C.CString("Hello")
+    defer C.free(unsafe.Pointer(cstr))
+    return cstr
 }
 
 func main(){}

--- a/section2/strings/string_output_round2.py
+++ b/section2/strings/string_output_round2.py
@@ -1,13 +1,15 @@
 import ctypes
 import os
 
+
 def main():
     path = os.path.join(os.path.abspath("."), "string_output_cgo.so")
-    lib = ctypes.CDLL(path)
+    lib = ctypes.cdll.LoadLibrary(path)
+    lib.string_output.restype = ctypes.c_char_p
     print("Answer is: ")
     print("-------------------")
     answer = lib.string_output()
-    print(ctypes.c_char_p(answer).value)
+    print(answer)
     print("-------------------\n\n")
 
 if __name__ == "__main__":

--- a/section3/commands.sh
+++ b/section3/commands.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 go build -o prime.so  -buildmode=c-shared prime.go
 go build -o prime_channel.so  -buildmode=c-shared prime_channel.go
 go build -o int_inputs.so  -buildmode=c-shared int_inputs.go


### PR DESCRIPTION
Marcus, great meeting you at PyGotham this past weekend. I took another look at the floats and strings issues you were having with your demo, and I managed to get it working. The trick is that ctypes allows you to specify a restype and argtypes on functions in the C libraries you import into Python so it knows what to expect. If you don't specify this, Python assumes any C function returns an int by default, which is why it was working for ints.
Here are the relevant docs:
https://docs.python.org/3/library/ctypes.html#return-types
https://docs.python.org/3/library/ctypes.html#ctypes._FuncPtr.restype

Hope this helps, and see you around at the meetup,
John
